### PR TITLE
Add CLI for creating test cases interactively

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cp node_modules/@wpaccessibility/wp-theme-auditor/jest.config.js ./
 cp -r node_modules/@wpaccessibility/wp-theme-auditor/test ./
 ```
 
-Then you'll need to add more test cases. `test/post.test.js` is included as an example.
+Then you'll need to add more test cases. You can do this interactively by running `create-test-case` from your theme's root directory.
 
 If, say, you wanted to test your theme's contact page, you might create a new test case called `contact.test.js` with modified content from `post.test.js` as follows:
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ From your theme's root directory, run the following commands:
 
 ```bash
 npm install --save-dev wpaccessibility/wp-theme-auditor
+npx npm-add-script -k "create-test-cases" -v "create-test-cases"
 npx npm-add-script -k "test:axe" -v "wp-scripts test-e2e"
 cp node_modules/@wpaccessibility/wp-theme-auditor/babel.config.js ./
 cp node_modules/@wpaccessibility/wp-theme-auditor/jest.config.js ./
 cp -r node_modules/@wpaccessibility/wp-theme-auditor/test ./
 ```
 
-Then you'll need to add more test cases. You can do this interactively by running `create-test-case` from your theme's root directory.
+Then you'll need to add more test cases. You can do this interactively by running `npm run create-test-case` from your theme's root directory.
 
 If, say, you wanted to test your theme's contact page, you might create a new test case called `contact.test.js` with modified content from `post.test.js` as follows:
 

--- a/README.md
+++ b/README.md
@@ -18,25 +18,34 @@ From your theme's root directory, run the following commands:
 npm install --save-dev wpaccessibility/wp-theme-auditor
 npx npm-add-script -k "create-test-cases" -v "create-test-cases"
 npx npm-add-script -k "test:axe" -v "wp-scripts test-e2e"
-cp node_modules/@wpaccessibility/wp-theme-auditor/babel.config.js ./
-cp node_modules/@wpaccessibility/wp-theme-auditor/jest.config.js ./
-cp -r node_modules/@wpaccessibility/wp-theme-auditor/test ./
 ```
 
 Then you'll need to add more test cases. You can do this interactively by running `npm run create-test-case` from your theme's root directory.
 
-If, say, you wanted to test your theme's contact page, you might create a new test case called `contact.test.js` with modified content from `post.test.js` as follows:
+If, say, you wanted to test your theme's contact page which has a slug of `contact`, you might create a new test case with the following inputs:
 
-```diff
+```bash
+$ npm run create-test-cases
+> twentynineteen@1.3.0 create-test-cases /Users/ned/Sites/a11y/wp-content/themes/twentynineteen
+> create-test-cases
+
+Creating test cases...
+? What is the post type? page
+? What is the slug of the post or page? contact
+? What is the title of the post or page? Contact page
+Test case created at /Users/ned/Sites/a11y/wp-content/themes/twentysixteen/test/contact.test.js.
+```
+
+The resulting test case file would contain the following content:
+
+```javascript
 /*global describe, beforeAll, page, it, expect */
 
 const { WP_BASE_URL } = require( './support/config' );
 
---describe( 'Single post', () => {
-++describe( 'Contact page', () => {
+describe( 'Contact page', () => {
 	beforeAll( async () => {
---		await page.goto( `${ WP_BASE_URL }/?p=1` );
-++		await page.goto( `${ WP_BASE_URL }/contact/` );
+		await page.goto( `${ WP_BASE_URL }/?pagename=contact` );
 	} );
 
 	it( 'Should pass Axe tests', async () => {

--- a/bin/create-test-cases.js
+++ b/bin/create-test-cases.js
@@ -7,7 +7,7 @@ const shell = require( 'shelljs' );
 
 const init = () => {
 	console.log(
-		chalk.green.bold( 'Creating test cases!' )
+		chalk.green.bold( 'Creating test cases...' )
 	);
 };
 
@@ -63,7 +63,7 @@ const createFile = ( posttype, slug, title ) => {
 
 const success = ( filepath ) => {
 	console.log(
-		chalk.green.bold( `Test case created at ${ filepath }` )
+		chalk.green.bold( `Test case created at ${ filepath }.` )
 	);
 };
 

--- a/bin/create-test-cases.js
+++ b/bin/create-test-cases.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+const chalk = require( 'chalk' );
+const handlebars = require( 'handlebars' );
+const inquirer = require( 'inquirer' );
+const shell = require( 'shelljs' );
+
+const init = () => {
+	console.log(
+		chalk.green.bold( 'Creating test cases!' )
+	);
+};
+
+const getTestCaseDetails = () => {
+	const questions = [
+		{
+			type: 'list',
+			name: 'POSTTYPE',
+			message: 'What is the post type?',
+			choices: [ 'post', 'page' ],
+			filter( val ) {
+				return val.split( '.' )[ 1 ];
+			},
+		},
+		{
+			name: 'SLUG',
+			type: 'input',
+			message: 'What is the slug of the post or page?',
+		},
+		{
+			name: 'TITLE',
+			type: 'input',
+			message: 'What is the title of the post or page?',
+		},
+	];
+	return inquirer.prompt( questions );
+};
+
+const doItAgain = () => {
+	const question = [
+		{
+			name: 'AGAIN',
+			type: 'confirm',
+			message: 'Create another test case?',
+		},
+	];
+	return inquirer.prompt( question );
+};
+
+const createFile = ( posttype, slug, title ) => {
+	const query = ( posttype === 'page' ) ? 'pagename' : 'name';
+	const tpl = shell.cat( `${ process.cwd() }/test/support/test.hbs` ).toString();
+	const data = {
+		title,
+		query,
+		slug,
+	};
+	const template = handlebars.compile( tpl );
+	const filePath = `${ process.cwd() }/test/${ slug }.test.js`;
+	new shell.ShellString( template( data ) ).to( filePath );
+	return filePath;
+};
+
+const success = ( filepath ) => {
+	console.log(
+		chalk.green.bold( `Test case created at ${ filepath }` )
+	);
+};
+
+const createTestCase = async () => {
+	const answers = await getTestCaseDetails();
+	const { POSTTYPE, SLUG, TITLE } = answers;
+	const filePath = createFile( POSTTYPE, SLUG, TITLE );
+	success( filePath );
+	const answer = await doItAgain();
+	const { AGAIN } = answer;
+	if ( AGAIN ) {
+		createTestCase();
+	}
+};
+
+const run = async () => {
+	init();
+	createTestCase();
+};
+
+run();

--- a/bin/postinstall.js
+++ b/bin/postinstall.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const chalk = require( 'chalk' );
+const shell = require( 'shelljs' );
+
+const init = () => {
+	console.log(
+		chalk.green.bold( 'Copying configuration files...' )
+	);
+};
+
+const copyFiles = () => {
+	const sourceDir = `${ process.env.INIT_CWD }/node_modules/@wpaccessibility/wp-theme-auditor`;
+	const destinationDir = process.env.INIT_CWD;
+	shell.cp( `${ sourceDir }/babel.config.js`, destinationDir );
+	shell.cp( `${ sourceDir }/jest.config.js`, destinationDir );
+	shell.cp( '-R', `${ sourceDir }/test`, `${ destinationDir }/test` );
+	return destinationDir;
+};
+
+const success = ( filepath ) => {
+	console.log(
+		chalk.green.bold( `Configuration files copied to ${ filepath }.` )
+	);
+};
+
+const run = async () => {
+	init();
+	const destinationDir = copyFiles();
+	success( destinationDir );
+};
+
+run();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4733,11 +4733,6 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
-    "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-    },
     "get-stdin": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -4911,11 +4906,11 @@
       }
     },
     "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+      "integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
@@ -5252,9 +5247,9 @@
       },
       "dependencies": {
         "strip-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-          "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -5698,6 +5693,11 @@
         "jest-cli": "^24.3.1"
       },
       "dependencies": {
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+        },
         "jest-cli": {
           "version": "24.3.1",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.3.1.tgz",
@@ -5716,6 +5716,36 @@
             "prompts": "^2.0.1",
             "realpath-native": "^1.1.0",
             "yargs": "^12.0.2"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "12.0.5",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+              "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^3.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -6009,6 +6039,41 @@
         "slash": "^2.0.0",
         "strip-bom": "^3.0.0",
         "yargs": "^12.0.2"
+      },
+      "dependencies": {
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "jest-serializer": {
@@ -6495,13 +6560,20 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mem": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-      "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+      "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
       "requires": {
         "map-age-cleaner": "^0.1.1",
-        "mimic-fn": "^1.0.0",
+        "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
+        }
       }
     },
     "memize": {
@@ -8055,6 +8127,14 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
@@ -8626,6 +8706,16 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -9539,21 +9629,15 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.1.tgz",
+      "integrity": "sha512-kI+3c+KphOAKIikQsZoT2oDsVYH5qvhpTtFObfMCdhPAYnjSvmW4oTWMhvDD4jtAGHJwztlBXQgozGcq3Xw9oQ==",
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.19.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "optional": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -10189,6 +10273,11 @@
             "homedir-polyfill": "^1.0.1"
           }
         },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+        },
         "global-modules": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -10218,6 +10307,34 @@
           "requires": {
             "expand-tilde": "^2.0.0",
             "global-modules": "^1.0.0"
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -10407,34 +10524,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yargs": {
-      "version": "12.0.5",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-      "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-      "requires": {
-        "cliui": "^4.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^3.0.0",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
-        "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^3.2.1 || ^4.0.0",
-        "yargs-parser": "^11.1.1"
-      }
-    },
-    "yargs-parser": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-      "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
     },
     "yauzl": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,11 @@
   "scripts": {
     "lint:js": "wp-scripts lint-js .",
     "lint:pkg-json": "wp-scripts lint-pkg-json .",
+    "postinstall": "postinstall",
     "test": "npm run -s lint:js && npm run -s lint:pkg-json"
   },
   "bin": {
-    "create-test-cases": "./bin/create-test-cases.js"
+    "create-test-cases": "./bin/create-test-cases.js",
+    "postinstall": "./bin/postinstall.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,11 +32,18 @@
     "@wordpress/jest-preset-default": "^4.0.0",
     "@wordpress/jest-puppeteer-axe": "^1.0.0",
     "@wordpress/scripts": "^3.0.0",
-    "core-js": "^2.6.5"
+    "chalk": "^2.4.2",
+    "core-js": "^2.6.5",
+    "handlebars": "^4.1.1",
+    "inquirer": "^6.2.2",
+    "shelljs": "^0.8.3"
   },
   "scripts": {
     "lint:js": "wp-scripts lint-js .",
     "lint:pkg-json": "wp-scripts lint-pkg-json .",
     "test": "npm run -s lint:js && npm run -s lint:pkg-json"
+  },
+  "bin": {
+    "create-test-cases": "./bin/create-test-cases.js"
   }
 }

--- a/test/support/test.hbs
+++ b/test/support/test.hbs
@@ -1,0 +1,13 @@
+/*global describe, beforeAll, page, it, expect */
+
+const { WP_BASE_URL } = require( './support/config' );
+
+describe( '{{ title }}', () => {
+	beforeAll( async () => {
+		await page.goto( `${ WP_BASE_URL }/?{{{ query }}}={{ slug }}` );
+	} );
+
+	it( 'Should pass Axe tests', async () => {
+		await expect( page ).toPassAxeTests();
+	} );
+} );


### PR DESCRIPTION
This PR adds a CLI command, `create-test-cases`, which can be used to interactively create test cases for specific posts or pages. Related to #1.